### PR TITLE
Always add P in String() method

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -122,6 +122,51 @@ func Parse(d string) (*Duration, error) {
 	return duration, nil
 }
 
+// Format formats the given duration into a ISO 8601 duration string (e.g. P1DT6H5M)
+func Format(d time.Duration) string {
+	neg := false
+	if d < 0 {
+		neg = true
+		d = -d
+	}
+
+	if d == 0 {
+		return "PT0S"
+	}
+
+	duration := &Duration{}
+	if d.Hours() >= 8760 {
+		duration.Years = math.Floor(d.Hours() / 8760)
+		d -= time.Duration(duration.Years) * time.Hour * 8760
+	}
+	if d.Hours() >= 730 {
+		duration.Months = math.Floor(d.Hours() / 730)
+		d -= time.Duration(duration.Months) * time.Hour * 730
+	}
+	if d.Hours() >= 168 {
+		duration.Weeks = math.Floor(d.Hours() / 168)
+		d -= time.Duration(duration.Weeks) * time.Hour * 168
+	}
+	if d.Hours() >= 24 {
+		duration.Days = math.Floor(d.Hours() / 24)
+		d -= time.Duration(duration.Days) * time.Hour * 24
+	}
+	if d.Hours() >= 1 {
+		duration.Hours = math.Floor(d.Hours())
+		d -= time.Duration(duration.Hours) * time.Hour
+	}
+	if d.Minutes() >= 1 {
+		duration.Minutes = math.Floor(d.Minutes())
+		d -= time.Duration(duration.Minutes) * time.Minute
+	}
+	duration.Seconds = d.Seconds()
+
+	if neg {
+		return "-" + duration.String()
+	}
+	return duration.String()
+}
+
 // ToTimeDuration converts the *Duration to the standard library's time.Duration
 // note that for *Duration's with period values of a month or year that the duration becomes a bit fuzzy
 // since obviously those things vary month to month and year to year
@@ -129,13 +174,27 @@ func Parse(d string) (*Duration, error) {
 func (duration *Duration) ToTimeDuration() time.Duration {
 	var timeDuration time.Duration
 
-	timeDuration += time.Duration(math.Round(duration.Years * 3.154e+16))
-	timeDuration += time.Duration(math.Round(duration.Months * 2.628e+15))
-	timeDuration += time.Duration(math.Round(duration.Weeks * 6.048e+14))
-	timeDuration += time.Duration(math.Round(duration.Days * 8.64e+13))
-	timeDuration += time.Duration(math.Round(duration.Hours * 3.6e+12))
-	timeDuration += time.Duration(math.Round(duration.Minutes * 6e+10))
-	timeDuration += time.Duration(math.Round(duration.Seconds * 1e+9))
+	if duration.Years != 0 {
+		timeDuration += time.Duration(math.Round(duration.Years * 3.154e+16))
+	}
+	if duration.Months != 0 {
+		timeDuration += time.Duration(math.Round(duration.Months * 2.628e+15))
+	}
+	if duration.Weeks != 0 {
+		timeDuration += time.Duration(math.Round(duration.Weeks * 6.048e+14))
+	}
+	if duration.Days != 0 {
+		timeDuration += time.Duration(math.Round(duration.Days * 8.64e+13))
+	}
+	if duration.Hours != 0 {
+		timeDuration += time.Duration(math.Round(duration.Hours * 3.6e+12))
+	}
+	if duration.Minutes != 0 {
+		timeDuration += time.Duration(math.Round(duration.Minutes * 6e+10))
+	}
+	if duration.Seconds != 0 {
+		timeDuration += time.Duration(math.Round(duration.Seconds * 1e+9))
+	}
 
 	return timeDuration
 }

--- a/duration.go
+++ b/duration.go
@@ -24,6 +24,19 @@ type Duration struct {
 const (
 	parsingPeriod = iota
 	parsingTime
+
+	hoursPerDay   = 24
+	hoursPerWeek  = hoursPerDay * 7
+	hoursPerMonth = hoursPerYear / 12
+	hoursPerYear  = hoursPerDay * 365
+
+	nsPerSecond = 1000000000
+	nsPerMinute = nsPerSecond * 60
+	nsPerHour   = nsPerMinute * 60
+	nsPerDay    = nsPerHour * hoursPerDay
+	nsPerWeek   = nsPerHour * hoursPerWeek
+	nsPerMonth  = nsPerHour * hoursPerMonth
+	nsPerYear   = nsPerHour * hoursPerYear
 )
 
 var (
@@ -135,29 +148,29 @@ func Format(d time.Duration) string {
 	}
 
 	duration := &Duration{}
-	if d.Hours() >= 8760 {
-		duration.Years = math.Floor(d.Hours() / 8760)
-		d -= time.Duration(duration.Years) * time.Hour * 8760
+	if d.Hours() >= hoursPerYear {
+		duration.Years = math.Floor(d.Hours() / hoursPerYear)
+		d -= time.Duration(duration.Years) * nsPerYear
 	}
-	if d.Hours() >= 730 {
-		duration.Months = math.Floor(d.Hours() / 730)
-		d -= time.Duration(duration.Months) * time.Hour * 730
+	if d.Hours() >= hoursPerMonth {
+		duration.Months = math.Floor(d.Hours() / hoursPerMonth)
+		d -= time.Duration(duration.Months) * nsPerMonth
 	}
-	if d.Hours() >= 168 {
-		duration.Weeks = math.Floor(d.Hours() / 168)
-		d -= time.Duration(duration.Weeks) * time.Hour * 168
+	if d.Hours() >= hoursPerWeek {
+		duration.Weeks = math.Floor(d.Hours() / hoursPerWeek)
+		d -= time.Duration(duration.Weeks) * nsPerWeek
 	}
-	if d.Hours() >= 24 {
-		duration.Days = math.Floor(d.Hours() / 24)
-		d -= time.Duration(duration.Days) * time.Hour * 24
+	if d.Hours() >= hoursPerDay {
+		duration.Days = math.Floor(d.Hours() / hoursPerDay)
+		d -= time.Duration(duration.Days) * nsPerDay
 	}
 	if d.Hours() >= 1 {
 		duration.Hours = math.Floor(d.Hours())
-		d -= time.Duration(duration.Hours) * time.Hour
+		d -= time.Duration(duration.Hours) * nsPerHour
 	}
 	if d.Minutes() >= 1 {
 		duration.Minutes = math.Floor(d.Minutes())
-		d -= time.Duration(duration.Minutes) * time.Minute
+		d -= time.Duration(duration.Minutes) * nsPerMinute
 	}
 	duration.Seconds = d.Seconds()
 
@@ -175,25 +188,25 @@ func (duration *Duration) ToTimeDuration() time.Duration {
 	var timeDuration time.Duration
 
 	if duration.Years != 0 {
-		timeDuration += time.Duration(math.Round(duration.Years * 3.154e+16))
+		timeDuration += time.Duration(math.Round(duration.Years * nsPerYear))
 	}
 	if duration.Months != 0 {
-		timeDuration += time.Duration(math.Round(duration.Months * 2.628e+15))
+		timeDuration += time.Duration(math.Round(duration.Months * nsPerMonth))
 	}
 	if duration.Weeks != 0 {
-		timeDuration += time.Duration(math.Round(duration.Weeks * 6.048e+14))
+		timeDuration += time.Duration(math.Round(duration.Weeks * nsPerWeek))
 	}
 	if duration.Days != 0 {
-		timeDuration += time.Duration(math.Round(duration.Days * 8.64e+13))
+		timeDuration += time.Duration(math.Round(duration.Days * nsPerDay))
 	}
 	if duration.Hours != 0 {
-		timeDuration += time.Duration(math.Round(duration.Hours * 3.6e+12))
+		timeDuration += time.Duration(math.Round(duration.Hours * nsPerHour))
 	}
 	if duration.Minutes != 0 {
-		timeDuration += time.Duration(math.Round(duration.Minutes * 6e+10))
+		timeDuration += time.Duration(math.Round(duration.Minutes * nsPerMinute))
 	}
 	if duration.Seconds != 0 {
-		timeDuration += time.Duration(math.Round(duration.Seconds * 1e+9))
+		timeDuration += time.Duration(math.Round(duration.Seconds * nsPerSecond))
 	}
 
 	return timeDuration

--- a/duration.go
+++ b/duration.go
@@ -142,13 +142,9 @@ func (duration *Duration) ToTimeDuration() time.Duration {
 
 // String returns the ISO8601 duration string for the *Duration
 func (duration *Duration) String() string {
-	d := ""
+	d := "P"
 
 	appendD := func(designator string, value float64, isTime bool) {
-		if !strings.Contains(d, "P") && !isTime {
-			d += "P"
-		}
-
 		if !strings.Contains(d, "T") && isTime {
 			d += "T"
 		}

--- a/duration_test.go
+++ b/duration_test.go
@@ -152,7 +152,7 @@ func TestDuration_String(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if smolDuration.String() != "T0.0000000000001S" {
-		t.Errorf("expected: %s, got: %s", "T0.0000000000001S", smolDuration.String())
+	if smolDuration.String() != "PT0.0000000000001S" {
+		t.Errorf("expected: %s, got: %s", "PT0.0000000000001S", smolDuration.String())
 	}
 }

--- a/duration_test.go
+++ b/duration_test.go
@@ -191,12 +191,12 @@ func TestDuration_String(t *testing.T) {
 		t.Errorf("expected: %s, got: %s", "P3Y6M4DT12H30M33.3333S", duration.String())
 	}
 
-	smolDuration, err := Parse("T0.0000000000001S")
+	smallDuration, err := Parse("T0.0000000000001S")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	if smolDuration.String() != "PT0.0000000000001S" {
-		t.Errorf("expected: %s, got: %s", "PT0.0000000000001S", smolDuration.String())
+	if smallDuration.String() != "PT0.0000000000001S" {
+		t.Errorf("expected: %s, got: %s", "PT0.0000000000001S", smallDuration.String())
 	}
 }

--- a/duration_test.go
+++ b/duration_test.go
@@ -60,6 +60,50 @@ func TestParse(t *testing.T) {
 	}
 }
 
+func TestFormat(t *testing.T) {
+	tests := []struct {
+		give time.Duration
+		want string
+	}{
+		{
+			give: 0,
+			want: "PT0S",
+		},
+		{
+			give: time.Minute * 94,
+			want: "PT1H34M",
+		},
+		{
+			give: time.Hour * 72,
+			want: "P3D",
+		},
+		{
+			give: time.Hour * 26,
+			want: "P1DT2H",
+		},
+		{
+			give: time.Second * 465461651,
+			want: "P14Y9M3DT12H54M11S",
+		},
+		{
+			give: -time.Hour * 99544,
+			want: "-P11Y4M1W4D",
+		},
+		{
+			give: -time.Second * 10,
+			want: "-PT10S",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			got := Format(tt.give)
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("Format() got = %s, want %s", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDuration_ToTimeDuration(t *testing.T) {
 	type fields struct {
 		Years   float64


### PR DESCRIPTION
As of now, when I create a duration like
```
duration.Duration{Minutes: 10}
```
and then calling `String()` returns `T10M` when `PT10M` is expected.