### PR TITLE
Implements encoding.TextMarshaler & encoding.TextUnmarshaler

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -309,3 +309,19 @@ func (duration *Duration) UnmarshalJSON(source []byte) error {
 	*duration = *parsed
 	return nil
 }
+
+// MarshalText implements [encoding.TextMarshaler].
+func (duration Duration) MarshalText() ([]byte, error) {
+	return []byte(duration.String()), nil
+}
+
+// UnmarshalText implements [encoding.TextUnmarshaler].
+func (duration *Duration) UnmarshalText(text []byte) error {
+	parsed, err := Parse(string(text))
+	if err != nil {
+		return fmt.Errorf("failed to parse duration: %w", err)
+	}
+
+	*duration = *parsed
+	return nil
+}

--- a/duration_test.go
+++ b/duration_test.go
@@ -342,3 +342,45 @@ func TestDuration_UnmarshalJSON(t *testing.T) {
 		t.Errorf("JSON Unmarshal ptr got = %s, want %s", &(durStruct.Dur), expected)
 	}
 }
+
+func TestDuration_MarshalText(t *testing.T) {
+	const orig = "P3Y6M4DT12H30M5.5S"
+	td, err := Parse(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	text, err := td.MarshalText()
+	if err != nil {
+		t.Errorf("did not expect error: %s", err)
+	}
+	if string(text) != orig {
+		t.Errorf("expected: %s, got: %s", orig, text)
+	}
+}
+
+func TestDuration_UnmarshalText(t *testing.T) {
+	const orig = `P3Y6M4DT12H30M5.5S`
+	expected, err := Parse(orig)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var dur Duration
+	err = dur.UnmarshalText([]byte(orig))
+	if err != nil {
+		t.Errorf("did not expect error: %s", err.Error())
+	}
+	if !reflect.DeepEqual(dur, *expected) {
+		t.Errorf("Text Unmarshal ptr got = %s, want %s", &dur, expected)
+	}
+
+	dur = Duration{}
+	err = (&dur).UnmarshalText([]byte(orig))
+	if err != nil {
+		t.Errorf("did not expect error: %s", err)
+	}
+	if !reflect.DeepEqual(dur, *expected) {
+		t.Errorf("Text Unmarshal ptr got = %s, want %s", &dur, expected)
+	}
+}


### PR DESCRIPTION
So `Duration` type can be used by serializers other than JSON, like YAML for example.