### PR TITLE
return an error when the expression is incomplete

### DIFF
--- a/duration.go
+++ b/duration.go
@@ -44,6 +44,8 @@ const (
 var (
 	// ErrUnexpectedInput is returned when an input in the duration string does not match expectations
 	ErrUnexpectedInput = errors.New("unexpected input")
+	// ErrIncompleteExpr is returned when the expression is incomplete, (e.g. missing unit).
+	ErrIncompleteExpr = errors.New("incomplete expression")
 )
 
 // Parse attempts to parse the given duration string into a *Duration,
@@ -143,6 +145,9 @@ func Parse(d string) (*Duration, error) {
 
 			return nil, ErrUnexpectedInput
 		}
+	}
+	if num != "" {
+		return nil, ErrIncompleteExpr
 	}
 
 	return duration, nil

--- a/duration_test.go
+++ b/duration_test.go
@@ -73,6 +73,18 @@ func TestParse(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name:    "no unit after prefix P",
+			args:    args{d: "P6"},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name:    "no unit after valid sub-prefix",
+			args:    args{d: "P7Y4"},
+			want:    nil,
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/duration_test.go
+++ b/duration_test.go
@@ -12,6 +12,15 @@ func TestParse(t *testing.T) {
 	type args struct {
 		d string
 	}
+	var (
+		noError    = func(e error) bool { return e == nil }
+		newMatchFn = func(expected error) func(e error) bool {
+			return func(e error) bool {
+				return errors.Is(e, expected)
+			}
+		}
+	)
+
 	tests := []struct {
 		name         string
 		args         args
@@ -22,19 +31,19 @@ func TestParse(t *testing.T) {
 			name:         "invalid-duration-1",
 			args:         args{d: "T0S"},
 			want:         nil,
-			errorMatchFn: func(e error) bool { return errors.Is(e, ErrUnexpectedInput) },
+			errorMatchFn: newMatchFn(ErrUnexpectedInput),
 		},
 		{
 			name:         "invalid-duration-2",
 			args:         args{d: "P-T0S"},
 			want:         nil,
-			errorMatchFn: func(e error) bool { return errors.Is(e, ErrUnexpectedInput) },
+			errorMatchFn: newMatchFn(ErrUnexpectedInput),
 		},
 		{
 			name:         "invalid-duration-3",
 			args:         args{d: "PT0SP0D"},
 			want:         nil,
-			errorMatchFn: func(e error) bool { return errors.Is(e, ErrUnexpectedInput) },
+			errorMatchFn: newMatchFn(ErrUnexpectedInput),
 		},
 		{
 			name: "period-only",
@@ -42,7 +51,7 @@ func TestParse(t *testing.T) {
 			want: &Duration{
 				Years: 4,
 			},
-			errorMatchFn: func(e error) bool { return e == nil },
+			errorMatchFn: noError,
 		},
 		{
 			name: "time-only-decimal",
@@ -50,7 +59,7 @@ func TestParse(t *testing.T) {
 			want: &Duration{
 				Seconds: 2.5,
 			},
-			errorMatchFn: func(e error) bool { return e == nil },
+			errorMatchFn: noError,
 		},
 		{
 			name: "full",
@@ -63,7 +72,7 @@ func TestParse(t *testing.T) {
 				Minutes: 30,
 				Seconds: 5.5,
 			},
-			errorMatchFn: func(e error) bool { return e == nil },
+			errorMatchFn: noError,
 		},
 		{
 			name: "negative",
@@ -72,19 +81,19 @@ func TestParse(t *testing.T) {
 				Minutes:  5,
 				Negative: true,
 			},
-			errorMatchFn: func(e error) bool { return e == nil },
+			errorMatchFn: noError,
 		},
 		{
 			name:         "no unit after prefix P",
 			args:         args{d: "P6"},
 			want:         nil,
-			errorMatchFn: func(e error) bool { return errors.Is(e, ErrIncompleteExpr) },
+			errorMatchFn: newMatchFn(ErrIncompleteExpr),
 		},
 		{
 			name:         "no unit after valid sub-prefix",
 			args:         args{d: "P7Y4"},
 			want:         nil,
-			errorMatchFn: func(e error) bool { return errors.Is(e, ErrIncompleteExpr) },
+			errorMatchFn: newMatchFn(ErrIncompleteExpr),
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes #35.

Introduces a new error `ErrIncompleteExpr` that is returned if the provided expression is unterminated.

It seems we expect the number buffer to be cleared if all terms are properly parsed, and if not - it means that the expression is missing a term.
